### PR TITLE
Add a CLI script

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var repo = require('../');
+
+if(!process.argv[2]) {
+  process.stdout.write('Missing argument: package' + "\n");
+  process.exit(1);
+}
+
+repo(process.argv[2], function(err, url) {
+  if(!err) {
+    process.stdout.write(url + "\n");
+    process.exit(0);
+  }
+  process.stderr.write(err.name + ': ' + err.message + "\n");
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "README.md"
   ],
   "main": "index.js",
+  "bin": "bin/cli.js",
   "engines": {
     "node": ">=0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "license": "MIT",
   "files": [
+    "bin/cli.js",
     "index.js",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
This pull request adds a CLI command `get-repository-url`. Usage example:

```bash
$ npm i -g get-repository-url
$ git clone $(get-repository-url assemble)
```